### PR TITLE
Enabling SPI support for the yocto build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,10 +9,64 @@ git submodule update
 # local.conf won't exist until this step on first execution
 source poky/oe-init-build-env
 
-CONFLINE="MACHINE = \"qemuarm64\""
+CONFLINE="MACHINE = \"raspberrypi3\""
+
+#Create image of the type rpi-sdimg
+IMAGE="IMAGE_FSTYPES = \"wic.bz2\""
+
+#Set GPU memory as minimum
+MEMORY="GPU_MEM = \"16\""
+
+#Add wifi support
+DISTRO_F="DISTRO_FEATURES:append = \" wifi bluetooth\""
+#add firmware support for SPI
+IMAGE_ADD="IMAGE_INSTALL:append = \" linux-firmware-rpidistro-bcm43430 v4l-utils python3 ntp wpa-supplicant spitools\""
+
+#Licence
+LICENCE="LICENSE_FLAGS_ACCEPTED  = \"commercial\""
+IMAGE_F="IMAGE_FEATURES += \"ssh-server-openssh tools-debug\""
+
+#Enable SPI bus
+MODULE_SPI="ENABLE_SPI_BUS = \"1\""
+
+#Autoload SPI module
+AUTOLOAD_SPI="KERNEL_MODULE_AUTOLOAD:rpi += \"spidev\""
+
+
+#Add extra packages is applicable
+CORE_IM_ADD="CORE_IMAGE_EXTRA_INSTALL += \"i2c-config server-config client-config gpio-config spi-config\""
 
 cat conf/local.conf | grep "${CONFLINE}" > /dev/null
 local_conf_info=$?
+
+cat conf/local.conf | grep "${IMAGE}" > /dev/null
+local_image_info=$?
+
+cat conf/local.conf | grep "${MEMORY}" > /dev/null
+local_memory_info=$?
+
+cat conf/local.conf | grep "${DISTRO_F}" > /dev/null
+local_distro_info=$?
+
+cat conf/local.conf | grep "${IMAGE_ADD}" > /dev/null
+local_imgadd_info=$?
+
+cat conf/local.conf | grep "${LICENCE}" > /dev/null
+local_licn_info=$?
+
+cat conf/local.conf | grep "${IMAGE_F}" > /dev/null
+local_imgf_info=$?
+
+cat conf/local.conf | grep "${MODULE_SPI}" > /dev/null
+local_spi_info=$?
+
+cat conf/local.conf | grep "${AUTOLOAD_SPI}" > /dev/null
+local_spi_autoload_info=$?
+
+cat conf/local.conf | grep "${CORE_IM_ADD}" > /dev/null
+local_coreimadd_info=$?
+
+
 
 if [ $local_conf_info -ne 0 ];then
 	echo "Append ${CONFLINE} in the local.conf file"
@@ -22,16 +76,164 @@ else
 	echo "${CONFLINE} already exists in the local.conf file"
 fi
 
+if [ $local_image_info -ne 0 ];then 
+    echo "Append ${IMAGE} in the local.conf file"
+	echo ${IMAGE} >> conf/local.conf
+else
+	echo "${IMAGE} already exists in the local.conf file"
+fi
 
-bitbake-layers show-layers | grep "meta-aesd" > /dev/null
+if [ $local_memory_info -ne 0 ];then
+    echo "Append ${MEMORY} in the local.conf file"
+	echo ${MEMORY} >> conf/local.conf
+else
+	echo "${MEMORY} already exists in the local.conf file"
+fi
+
+if [ $local_distro_info -ne 0 ];then
+    echo "Append ${DISTRO_F} in the local.conf file"
+	echo ${DISTRO_F} >> conf/local.conf
+else
+	echo "${DISTRO_F} already exists in the local.conf file"
+fi
+
+if [ $local_imgadd_info -ne 0 ];then
+    echo "Append ${IMAGE_ADD} in the local.conf file"
+	echo ${IMAGE_ADD} >> conf/local.conf
+else
+	echo "${IMAGE_ADD} already exists in the local.conf file"
+fi
+
+if [ $local_licn_info -ne 0 ];then
+    echo "Append ${LICENCE} in the local.conf file"
+	echo ${LICENCE} >> conf/local.conf
+else
+	echo "${LICENCE} already exists in the local.conf file"
+fi
+
+if [ $local_imgf_info -ne 0 ];then
+    echo "Append ${IMAGE_F} in the local.conf file"
+	echo ${IMAGE_F} >> conf/local.conf
+else
+	echo "${IMAGE_F} already exists in the local.conf file"
+fi
+
+if [ $local_spi_info -ne 0 ];then
+        echo "Append ${MODULE_SPI} in the local.conf file"
+        echo ${MODULE_SPI} >> conf/local.conf
+else
+        echo "${MODULE_SPI} already exists in the local.conf file"
+fi
+
+if [ $local_spi_autoload_info -ne 0 ];then
+        echo "Append ${AUTOLOAD_SPI} in the local.conf file"
+        echo ${AUTOLOAD_SPI} >> conf/local.conf
+else
+        echo "${AUTOLOAD_SPI} already exists in the local.conf file"
+fi
+
+
+if [ $local_coreimadd_info -ne 0 ];then
+        echo "Append ${CORE_IM_ADD} in the local.conf file"
+        echo ${CORE_IM_ADD} >> conf/local.conf       
+else
+        echo "${CORE_IM_ADD} already exists in the local.conf file"
+fi
+
+bitbake-layers show-layers | grep "meta-raspberrypi" > /dev/null
+layer_info=$?
+
+bitbake-layers show-layers | grep "meta-python" > /dev/null
+layer_python_info=$?
+
+bitbake-layers show-layers | grep "meta-oe" > /dev/null
+layer_metaoe_info=$?
+
+bitbake-layers show-layers | grep "meta-networking" > /dev/null
+layer_networking_info=$?
+
+bitbake-layers show-layers | grep "meta-i2c" > /dev/null
+layer_i2c_info=$?
+
+bitbake-layers show-layers | grep "meta-server" > /dev/null
+layer_server_info=$?
+
+bitbake-layers show-layers | grep "meta-client" > /dev/null
+layer_client_info=$?
+
+bitbake-layers show-layers | grep "meta-spi" > /dev/null
+layer_spi_info=$?
+
+if [ $layer_metaoe_info -ne 0 ];then
+    echo "Adding meta-oe layer"
+	bitbake-layers add-layer ../meta-openembedded/meta-oe
+else
+	echo "layer meta-oe already exists"
+fi
+
+
+if [ $layer_python_info -ne 0 ];then
+    echo "Adding meta-python layer"
+	bitbake-layers add-layer ../meta-openembedded/meta-python
+else
+	echo "layer meta-python already exists"
+fi
+
+
+if [ $layer_networking_info -ne 0 ];then
+    echo "Adding meta-networking layer"
+	bitbake-layers add-layer ../meta-openembedded/meta-networking
+else
+	echo "layer meta-networking already exists"
+fi
+
+
+if [ $layer_info -ne 0 ];then
+	echo "Adding meta-raspberrypi layer"
+	bitbake-layers add-layer ../meta-raspberrypi
+else
+	echo "layer meta-raspberrypi already exists"
+fi
+
+if [ $layer_i2c_info -ne 0 ];then
+        echo "Adding meta-i2c layer"
+        bitbake-layers add-layer ../meta-i2c
+else
+        echo "meta-i2c layer already exists"
+fi
+
+
+if [ $layer_server_info -ne 0 ];then
+        echo "Adding meta-server layer"
+        bitbake-layers add-layer ../meta-server
+else
+        echo "meta-server layer already exists"
+fi
+
+if [ $layer_client_info -ne 0 ];then
+        echo "Adding meta-client layer"
+        bitbake-layers add-layer ../meta-client
+else
+        echo "meta-client layer already exists"
+fi
+
+if [ $layer_spi_info -ne 0 ];then
+        echo "Adding meta-spi layer"
+        bitbake-layers add-layer ../meta-spi
+else
+        echo "meta-spi layer already exists"
+fi
+
+bitbake-layers show-layers | grep "meta-gpio" > /dev/null
 layer_info=$?
 
 if [ $layer_info -ne 0 ];then
-	echo "Adding meta-aesd layer"
-	bitbake-layers add-layer ../meta-aesd
+	echo "Adding meta-gpio layer"
+	bitbake-layers add-layer ../meta-gpio
 else
-	echo "meta-aesd layer already exists"
-fi
+	echo "meta-gpio layer already exists"
+fi 
 
 set -e
-bitbake core-image-aesd
+
+bitbake core-image-base

--- a/meta-spi/COPYING.MIT
+++ b/meta-spi/COPYING.MIT
@@ -1,0 +1,17 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy 
+of this software and associated documentation files (the "Software"), to deal 
+in the Software without restriction, including without limitation the rights 
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+copies of the Software, and to permit persons to whom the Software is 
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in 
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
+THE SOFTWARE.

--- a/meta-spi/README
+++ b/meta-spi/README
@@ -1,0 +1,41 @@
+This README file contains information on the contents of the meta-spi layer.
+
+Please see the corresponding sections below for details.
+
+Dependencies
+============
+
+  URI: <first dependency>
+  branch: <branch name>
+
+  URI: <second dependency>
+  branch: <branch name>
+
+  .
+  .
+  .
+
+Patches
+=======
+
+Please submit any patches against the meta-spi layer to the xxxx mailing list (xxxx@zzzz.org)
+and cc: the maintainer:
+
+Maintainer: XXX YYYYYY <xxx.yyyyyy@zzzzz.com>
+
+Table of Contents
+=================
+
+  I. Adding the meta-spi layer to your build
+ II. Misc
+
+
+I. Adding the meta-spi layer to your build
+=================================================
+
+Run 'bitbake-layers add-layer meta-spi'
+
+II. Misc
+========
+
+--- replace with specific information about the meta-spi layer ---

--- a/meta-spi/conf/layer.conf
+++ b/meta-spi/conf/layer.conf
@@ -1,0 +1,13 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "meta-spi"
+BBFILE_PATTERN_meta-spi = "^${LAYERDIR}/"
+BBFILE_PRIORITY_meta-spi = "5"
+
+LAYERDEPENDS_meta-spi = "core"
+LAYERSERIES_COMPAT_meta-spi = "kirkstone"

--- a/meta-spi/recipes-config/spi-config/spi-config_0.1.bb
+++ b/meta-spi/recipes-config/spi-config/spi-config_0.1.bb
@@ -1,5 +1,5 @@
 # See http://git.yoctoproject.org/cgit.cgi/poky/tree/meta/files/common-licenses
-LICENSE = "MIT"
+LICENSE = "GPL Version 2"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
 # TODO: Set this  with the path to your assignments rep.  Use ssh protocol and see lecture notes

--- a/meta-spi/recipes-config/spi-config/spi-config_0.1.bb
+++ b/meta-spi/recipes-config/spi-config/spi-config_0.1.bb
@@ -1,0 +1,44 @@
+# See http://git.yoctoproject.org/cgit.cgi/poky/tree/meta/files/common-licenses
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+# TODO: Set this  with the path to your assignments rep.  Use ssh protocol and see lecture notes
+# about how to setup ssh-agent for passwordless access
+SRC_URI = "git://git@github.com/cu-ecen-aeld/Finalproject-Shreyan-Bala-shared.git;protocol=ssh;branch=master"
+
+PV = "1.0+git${SRCPV}"
+# TODO: set to reference a specific commit hash in your assignment repo
+SRCREV = "${AUTOREV}"
+
+# This sets your staging directory based on WORKDIR, where WORKDIR is defined at 
+# https://www.yoctoproject.org/docs/latest/ref-manual/ref-manual.html#var-WORKDIR
+# We reference the "server" directory here to build from the "server" directory
+# in your assignments repo
+S = "${WORKDIR}/git"
+B = "${S}/spi_package"
+
+# TODO: Add the aesdsocket application and any other files you need to install
+# See http://git.yoctoproject.org/cgit.cgi/poky/plain/meta/conf/bitbake.conf?h=warrior for yocto path prefixes
+FILES_${PN} += "${bindir}/spidevtest"
+
+# TODO: customize these as necessary for any libraries you need for your application
+
+do_configure () {
+	:
+}
+
+do_compile () {
+	oe_runmake
+}
+
+do_install () {
+	# TODO: Install your binaries/scripts here.
+	# Be sure to install the target directory with install -d first
+	# Yocto variables ${D} and ${S} are useful here, which you can read about at 
+	# https://www.yoctoproject.org/docs/latest/ref-manual/ref-manual.html#var-D
+	# and
+	# https://www.yoctoproject.org/docs/latest/ref-manual/ref-manual.html#var-S
+	# See example at https://github.com/cu-ecen-aeld/ecen5013-yocto/blob/ecen5013-hello-world/meta-ecen5013/recipes-ecen5013/ecen5013-hello-world/ecen5013-hello-world_git.bb
+	install -d ${D}${bindir}
+	install -m 0755 ${B}/spidevtest ${D}${bindir}/
+}


### PR DESCRIPTION
Following features added to the build script for SPI support:
1. Raspberry pi boot configuration by adding meta-poky, meta-openembedded and meta-raspberrypi. (dunfell branch)
2. SPI module enabled for raspberry-pi and autoloaded on boot
3. spidev tools added for detecting the spi devices connected to the raspberry-pi SPI bus.
4. Necassary changes are updated in the local.conf file
5. Verification of the above functionalities done for raspberry-pi 3b+